### PR TITLE
Add author and repository entries to document

### DIFF
--- a/src/cmd/code2vec_extract_features.py
+++ b/src/cmd/code2vec_extract_features.py
@@ -4,8 +4,11 @@ from uuid import uuid4
 from extractors.paths import UastPathsBagExtractor
 from transformers.vocabulary2id import Vocabulary2Id
 from sourced.ml.transformers import UastDeserializer, Uast2BagFeatures, create_uast_source, \
-    UastRow2Document, Moder
+     Moder
 from sourced.ml.utils.engine import pipeline_graph, pause
+
+from extractors.extended_document_features import UastRow2ExtendedDocument
+from transformers.deanonymizer import Deanonymizer
 
 
 @pause
@@ -15,8 +18,9 @@ def code2vec_extract_features(args):
     root, start_point = create_uast_source(args, session_name)
 
     res = start_point \
+        .link(Deanonymizer(root)) \
         .link(Moder("func")) \
-        .link(UastRow2Document()) \
+        .link(UastRow2ExtendedDocument()) \
         .link(UastDeserializer()) \
         .link(Uast2BagFeatures([UastPathsBagExtractor(args.max_length, args.max_width)])) \
         .link(Vocabulary2Id(root.session.sparkContext, args.output)) \

--- a/src/extractors/extended_document_features.py
+++ b/src/extractors/extended_document_features.py
@@ -1,0 +1,43 @@
+from typing import Union
+
+from pyspark import RDD, Row
+from pyspark.sql import DataFrame
+
+from sourced.ml.transformers.transformer import Transformer
+from sourced.ml.transformers.uast2bag_features import Uast2BagFeatures
+
+from utils.extended_document_constants import ExtendedDocumentConstants
+
+
+class UastRow2ExtendedDocument(Transformer):
+    """
+    Converts UAST rows into document rows with author and repo entries.
+
+    This class is based on sourced.ml.transformers.uast2bag_features.UastRow2Document
+    and returns the same doc and uast entries. The difference between
+    a doc object and an extended doc object is that the extended doc
+    includes separate author and repository id entries to be easily used
+    later during training.
+    """
+
+    REPO_PATH_SEP = "//"
+    PATH_BLOB_SEP = "@"
+
+    def __call__(self, rows: Union[RDD, DataFrame]):
+        if isinstance(rows, DataFrame):
+            rows = rows.rdd
+
+        return rows.map(self.documentize)
+
+    def documentize(self, r: Row) -> Row:
+        ec = ExtendedDocumentConstants.Columns
+
+        doc = r[ec.RepositoryId]
+        if r[ec.Path]:
+            doc += self.REPO_PATH_SEP + r[ec.Path]
+        if r[ec.BlobId]:
+            doc += self.PATH_BLOB_SEP + r[ec.BlobId]
+
+        bfc = Uast2BagFeatures.Columns
+        return Row(**{bfc.document: doc, ec.RepositoryId: r[ec.RepositoryId],
+                      ec.Author: r[ec.Author], ec.Uast: r[ec.Uast]})

--- a/src/transformers/deanonymizer.py
+++ b/src/transformers/deanonymizer.py
@@ -1,0 +1,40 @@
+from pyspark.sql import DataFrame
+
+from sourced.engine import Engine
+from sourced.ml.transformers.transformer import Transformer
+
+from utils.blob_constants import BlobConstants
+from utils.commit_author_constants import CommitAuthorConstants
+
+
+class Deanonymizer(Transformer):
+    """
+    Adds author id to blob row.
+
+    The author id is added by joining the input blobs dataframe
+    with the commits dataframe by commit hash. The commits dataframe
+    needs to be recovered from the root engine object specified
+    in the constructor.
+    """
+
+    def __init__(self, engine: Engine, **kwargs):
+        super().__init__(**kwargs)
+        self.engine = engine
+
+    def __call__(self, rows: DataFrame):
+        return self.deanonymize(rows)
+
+    def deanonymize(self, d: DataFrame) -> DataFrame:
+        hash_authors = self.engine.repositories.references \
+                                  .head_ref.commits \
+                                  .select("hash", "author_email")
+
+        bc = BlobConstants.Columns
+        cac = CommitAuthorConstants.Columns
+
+        deanonymized = \
+            d.join(hash_authors,
+                   (d[bc.CommitHash] == hash_authors[cac.CommitHash]))\
+             .drop(cac.CommitHash)
+
+        return deanonymized

--- a/src/utils/blob_constants.py
+++ b/src/utils/blob_constants.py
@@ -1,0 +1,17 @@
+class BlobConstants:
+    """
+    Constants to use blob information in Engine.
+    """
+    class Columns:
+        """
+        Column names constants.
+        """
+        BlobId = "blob_id"
+        CommitHash = "commit_hash"
+        RepositoryId = "repository_id"
+        ReferenceName = "reference_name"
+        Content = "content"
+        IsBinary = "is_binary"
+        Path = "path"
+        Lang = "lang"
+        Uast = "uast"

--- a/src/utils/commit_author_constants.py
+++ b/src/utils/commit_author_constants.py
@@ -1,0 +1,10 @@
+class CommitAuthorConstants:
+    """
+    Constants to use commit author information in Engine.
+    """
+    class Columns:
+        """
+        Column names constants.
+        """
+        CommitHash = "hash"
+        Author = "author_email"

--- a/src/utils/extended_document_constants.py
+++ b/src/utils/extended_document_constants.py
@@ -1,0 +1,13 @@
+class ExtendedDocumentConstants:
+    """
+    Constants to use extended document information in Engine.
+    """
+    class Columns:
+        """
+        Column names constants.
+        """
+        RepositoryId = "repository_id"
+        Path = "path"
+        BlobId = "blob_id"
+        Uast = "uast"
+        Author = "author_email"


### PR DESCRIPTION
The changes proposed provide with separate repository and author entries for each function UAST document.

This information can be used to experiment with different train/test partitions based on repository or author.

Signed-off-by: Alejandro Sanchez Medina <alejandrosanchzmedina@gmail.com>